### PR TITLE
Localize method should be derived from object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
     packages:
     - google-chrome-stable
 before_script:
-- yarn add polymer-cli
+- yarn add polymer-cli -g
 - polymer install --variants
 script:
 - xvfb-run wct --skip-plugin sauce

--- a/px-inbox.html
+++ b/px-inbox.html
@@ -59,7 +59,7 @@ Custom property | Description | Default
                 button-style="bare"
                 selected="{{sortBy}}"
                 display-value="{{localize(sortBy)}}"
-                items="[[_getLocalizedSortOptions(localize)]]"
+                items="[[_getLocalizedSortOptions()]]"
                 disable-clear>
             </px-dropdown>
           </div>
@@ -78,7 +78,7 @@ Custom property | Description | Default
                     <div class="subtitle flex__item">{{listItem.subtitle}}</div>
                   </div>
                 </div>
-                <span class="info">{{_getFormattedDate(listItem.date, localize)}}</span>
+                <span class="info">{{_getFormattedDate(listItem.date)}}</span>
               </div>
             </li>
           </template>
@@ -282,19 +282,19 @@ Custom property | Description | Default
         }
       }, 500);
     },
-    _getFormattedDate: function(date, localize) {
+    _getFormattedDate: function(date) {
       if (typeof date === 'string' && this._isValidDate(date)) {
-        return this._formatDateFromNow(new Date(date), new Date(), localize);
+        return this._formatDateFromNow(new Date(date), new Date());
       }
       if(date instanceof Date && this._isValidDate(date)) {
-        return this._formatDateFromNow(date, new Date(), localize);
+        return this._formatDateFromNow(date, new Date());
       }
       return date;
     },
     _isValidDate: function(dateString) {
       return !isNaN(new Date(dateString).getTime());
     },
-    _formatDateFromNow: function(date, nowDate, localize) {
+    _formatDateFromNow: function(date, nowDate) {
       const seconds = Math.floor((nowDate - date) / 1000);
       const years = Math.floor(seconds / 31536000);
       const months = Math.floor(seconds / 2592000);
@@ -408,12 +408,12 @@ Custom property | Description | Default
         return 'px-nav:down';
       }
     },
-    _getLocalizedSortOptions: function(localize) {
+    _getLocalizedSortOptions: function() {
       return [
-        { "key": "Title", "val": localize("Title") },
-        { "key": "Subtitle", "val": localize("Subtitle") },
-        { "key": "Severity", "val": localize("Severity") },
-        { "key": "Date", "val": localize("Date") }
+        { "key": "Title", "val": this.localize("Title") },
+        { "key": "Subtitle", "val": this.localize("Subtitle") },
+        { "key": "Severity", "val": this.localize("Severity") },
+        { "key": "Date", "val": this.localize("Date") }
       ];
     },
     _getSelectedItemClassName: function(selectedId, id) {

--- a/test/px-inbox-tests.js
+++ b/test/px-inbox-tests.js
@@ -64,81 +64,80 @@ describe('px-inbox', () => {
 
 describe('px-inbox date formatting', () => {
   let inboxEl;
-  const localizeStub = str => str;
-
+  
   beforeEach((done) => {
     inboxEl = fixture('InboxFixture');
     flush(done);
   });
 
   it('does not format dates that are not valid ISO-8601 strings', () => {
-    assert.equal(inboxEl._getFormattedDate('a long time ago', ()=>null), 'a long time ago');
+    assert.equal(inboxEl._getFormattedDate('a long time ago'), 'a long time ago');
   });
 
   it('correctly formats time a few seconds ago', () => {
     const nowDate = new Date('2016-10-05T08:00:00');
     const pastDate = new Date('2016-10-05T07:59:16'); // 44 seconds before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), 'a few seconds ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), 'a few seconds ago');
   });
 
   it('correctly formats time a minute ago', () => {
     const nowDate = new Date('2016-10-05T08:00:00');
     const pastDate = new Date('2016-10-05T07:59:15'); // 45 seconds before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), 'a minute ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), 'a minute ago');
   });
 
   it('correctly formats time [n] minutes ago', () => {
     const nowDate = new Date('2016-10-05T08:00:00');
     const pastDate = new Date('2016-10-05T07:16:00'); // 44 minutes before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), '44 minutes ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), '44 minutes ago');
   });
 
   it('correctly formats time an hour ago', () => {
     const nowDate = new Date('2016-10-05T08:00:00');
     const pastDate = new Date('2016-10-05T07:15:00'); // 45 minutes before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), 'an hour ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), 'an hour ago');
   });
 
   it('correctly formats time [n] hours ago', () => {
     const nowDate = new Date('2016-10-05T23:00:00');
     const pastDate = new Date('2016-10-05T02:00:00'); // 21 hours before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), '21 hours ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), '21 hours ago');
   });
 
   it('correctly formats time a day ago', () => {
     const nowDate = new Date('2016-10-05T23:00:00');
     const pastDate = new Date('2016-10-05T01:00:00'); // 22 hours before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), 'a day ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), 'a day ago');
   });
 
   it('correctly formats time [n] days ago', () => {
     const nowDate = new Date('2016-10-28T23:00:00');
     const pastDate = new Date('2016-10-03T23:00:00'); // 25 days before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), '25 days ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), '25 days ago');
   });
 
   it('correctly formats time a month ago', () => {
     const nowDate = new Date('2016-10-28T23:00:00');
     const pastDate = new Date('2016-10-02T23:00:00'); // 26 days before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), 'a month ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), 'a month ago');
   });
 
   it('correctly formats time [n] months ago', () => {
     const nowDate = new Date('2016-12-10T23:00:00');
     const pastDate = new Date('2016-02-10T23:00:00'); // 10 months before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), '10 months ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), '10 months ago');
   });
 
   it('correctly formats time a year ago', () => {
     const nowDate = new Date('2016-12-10T23:00:00');
     const pastDate = new Date('2016-01-10T23:00:00'); // 11 months before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), 'a year ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), 'a year ago');
   });
 
   it('correctly formats time [n] years ago', () => {
     const nowDate = new Date('2016-12-10T23:00:00');
     const pastDate = new Date('2013-12-10T23:00:00'); // 3 years before nowDate
-    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate, localizeStub), '3 years ago');
+    assert.equal(inboxEl._formatDateFromNow(pastDate, nowDate), '3 years ago');
   });
 
   it('handles date objects correctly', () => {


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
-  Removing the 3rd argument  ` localize ` as this is not used 
- Using ` this.localize ` in all required methods

* ## A reference to a related issue (if applicable):
- https://github.com/PredixDev/px-inbox/commit/8f4e1ec827eb78066e329298e1190ab250d597dc

* ## @mentions of the person or team responsible for reviewing proposed changes:
@randyaskin 

* ## working tests:
Waiting for the build result from https://travis-ci.org/sks/px-inbox/builds/337798492

Will make any fixes as required